### PR TITLE
Run e2fsck with -p flag

### DIFF
--- a/scripts/expand.sh
+++ b/scripts/expand.sh
@@ -47,7 +47,7 @@ parted $LOOP_BASE --script rm 2
 parted $LOOP_BASE --script mkpart primary ${RESIZE_START} ${RESIZE_END}
 
 # Check and resize file system
-e2fsck -f $LOOP_P2
+e2fsck -p -f $LOOP_P2
 resize2fs $LOOP_P2
 
 # Cleanup loopbacks


### PR DESCRIPTION
`e2fsck` failed in our scripts. 
Using `e2fsck -p` fixes the issue. 

```
$ man e2fsck
 ...
 -p     Automatically repair ("preen") the file system.  This option
              will cause e2fsck to automatically fix any filesystem problems
              that can be safely fixed without human intervention. ...
 ...
```